### PR TITLE
Non functional change. Initialize var EnumVal to 0. (#82987)

### DIFF
--- a/llvm/utils/TableGen/CodeGenInstruction.h
+++ b/llvm/utils/TableGen/CodeGenInstruction.h
@@ -301,7 +301,7 @@ public:
   Record *InferredFrom;
 
   // The enum value assigned by CodeGenTarget::computeInstrsByEnum.
-  mutable unsigned EnumVal;
+  mutable unsigned EnumVal = 0;
 
   CodeGenInstruction(Record *R);
 


### PR DESCRIPTION
CodeGenInstruction has a new unsigned member EnumVal. It is not
initialized in either the class or the constructor.

---

**Stack**:
- #9
- #8
- #7
- #6
- #5
- #4
- #3
- #2
- #1


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*